### PR TITLE
feat : 최근본 유저와 토론을 저장할 Model(테이블 생성) 및 토론상세페이지 요청 시 로직 추가

### DIFF
--- a/src/main/java/store/itpick/backend/controller/DebateController.java
+++ b/src/main/java/store/itpick/backend/controller/DebateController.java
@@ -100,4 +100,14 @@ public class DebateController {
 
         return new BaseResponse<>(debates);
     }
+
+    @GetMapping("/recent")
+    public BaseResponse<List<DebateByKeywordDTO>> getRecentViewedDebate(@RequestHeader("Authorization") String token) {
+
+        String jwtToken = token.substring(7);
+
+        List<DebateByKeywordDTO> debateResponse = debateService.getRecentViewedDebate(jwtToken);
+
+        return new BaseResponse<>(debateResponse);
+    }
 }

--- a/src/main/java/store/itpick/backend/model/RecentViewedDebate.java
+++ b/src/main/java/store/itpick/backend/model/RecentViewedDebate.java
@@ -1,0 +1,30 @@
+package store.itpick.backend.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.sql.Timestamp;
+
+
+@Entity
+@Table(name = "recent_viewed_debate")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecentViewedDebate {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recent_viewed_debate_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "debate_id", nullable = false)
+    private Debate debate;
+
+    @Column(name = "viewed_at", nullable = false)
+    private Timestamp viewedAt;
+}

--- a/src/main/java/store/itpick/backend/repository/RecentViewedDebateRepository.java
+++ b/src/main/java/store/itpick/backend/repository/RecentViewedDebateRepository.java
@@ -1,0 +1,14 @@
+package store.itpick.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import store.itpick.backend.model.RecentViewedDebate;
+
+import java.util.List;
+
+@Repository
+public interface RecentViewedDebateRepository extends JpaRepository<RecentViewedDebate, Long> {
+    List<RecentViewedDebate> findByUser_UserIdOrderByViewedAtDesc(Long userId);
+
+}
+

--- a/src/main/java/store/itpick/backend/service/DebateService.java
+++ b/src/main/java/store/itpick/backend/service/DebateService.java
@@ -224,7 +224,7 @@ public class DebateService {
         for (Debate debate : debates) {
             String title= debate.getTitle();
             String content =debate.getContent();
-            String mediaUrl =null;
+            String mediaUrl =debate.getImageUrl();
             Long hit = debate.getHits();
             Long comment = (long) debate.getComment().size();
             debateList.add(new DebateByKeywordDTO(title,content,mediaUrl,hit,comment));

--- a/src/main/java/store/itpick/backend/service/DebateService.java
+++ b/src/main/java/store/itpick/backend/service/DebateService.java
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static store.itpick.backend.common.response.status.BaseExceptionResponseStatus.*;
 
@@ -39,6 +40,7 @@ public class DebateService {
     private final VoteService voteService;
     private final JwtProvider jwtProvider;
     private final S3ImageBucketService s3ImageBucketService;
+    private final RecentViewedDebateRepository recentViewedDebateRepository;
 
     @Transactional
     public PostDebateResponse createDebate(PostDebateRequest postDebateRequest) {
@@ -148,6 +150,11 @@ public class DebateService {
         Debate debate = debateRepository.findById(debateId)
                 .orElseThrow(() -> new DebateException(DEBATE_NOT_FOUND));
 
+
+        // 최근 본 토론 기록 생성 및 저장
+        saveRecentViewedDebate(userId, debate);
+
+
         debate.setHits(debate.getHits() + 1);
         debateRepository.save(debate);
 
@@ -233,4 +240,39 @@ public class DebateService {
         return debateList;
 
     }
+    private void saveRecentViewedDebate(Long userId, Debate debate) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+
+        RecentViewedDebate recentViewedDebate = new RecentViewedDebate();
+        recentViewedDebate.setUser(user);
+        recentViewedDebate.setDebate(debate);
+        recentViewedDebate.setViewedAt(new Timestamp(System.currentTimeMillis())); // 시청 시간을 저장
+
+        recentViewedDebateRepository.save(recentViewedDebate);
+    }
+
+    public List<DebateByKeywordDTO> getRecentViewedDebate(String token){
+        if (jwtProvider.isExpiredToken(token)) {
+            throw new JwtUnauthorizedTokenException(INVALID_TOKEN);
+        }
+
+        Long userId = jwtProvider.getUserIdFromToken(token);
+
+        List<RecentViewedDebate> recentViewedDebates = recentViewedDebateRepository.findByUser_UserIdOrderByViewedAtDesc(userId);
+
+        // Debate ID를 통해 Debate 엔티티를 조회
+        List<Long> debateIds = recentViewedDebates.stream()
+                .map(recentViewedDebate -> recentViewedDebate.getDebate().getDebateId())
+                .collect(Collectors.toList());
+
+        List<Debate> debates = debateRepository.findAllById(debateIds);
+
+        // Debate를 DTO로 변환
+        return debates.stream()
+                .map(debate -> new DebateByKeywordDTO(debate.getTitle(), debate.getContent(), debate.getImageUrl(),debate.getHits(), (long) debate.getComment().size()))
+                .collect(Collectors.toList());
+
+    }
+
 }


### PR DESCRIPTION
<img width="499" alt="image" src="https://github.com/user-attachments/assets/f320a22a-e724-45ac-969c-7005a9cd361e"> </br>
- 최근 토론을 조회한 유저를 저장해 두기 위해서, User와 Debate 사이에 테이블을 하나 만들어서 Mapping해주었습니다

<img width="637" alt="image" src="https://github.com/user-attachments/assets/926ce9ac-4870-4577-a5c2-bbaf31191e25">  </br>
- 기존 토론상세페이지 조회 로직에 saveRecentViewedDebate 함수를 호출하여 DB에 저장하도록 하였습니다
- 아래는 saveRecentViewedDebate 함수입니다
<img width="830" alt="image" src="https://github.com/user-attachments/assets/1ca9f0aa-9858-42bc-ba20-4008abbb3f40">
