### PR TITLE
feat : 3일내에 만든 토론중에, 가장 조회수가 높은걸 반환하도록 함

### DIFF
--- a/src/main/java/store/itpick/backend/config/WebConfig.java
+++ b/src/main/java/store/itpick/backend/config/WebConfig.java
@@ -29,7 +29,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(jwtAuthenticationInterceptor)
                 .order(1)
                 .addPathPatterns("/**")
-                .excludePathPatterns("/auth/login", "/auth/signup", "/auth/refresh","/auth/emails/**", "/rank/**","/auth/email/check","/auth/nickname/check","/favicon.ico","/keyword/**","/debate/keyword", "/test/**");
+                .excludePathPatterns("/auth/login", "/auth/signup", "/auth/refresh","/auth/emails/**", "/rank/**","/auth/email/check","/auth/nickname/check","/favicon.ico","/keyword/**","/debate/keyword", "/test/**","/debate/trend");
                  //인터셉터 적용 범위 수정
         registry.addInterceptor(getJwtInterceptor)
                 .addPathPatterns("/user/email");

--- a/src/main/java/store/itpick/backend/controller/DebateController.java
+++ b/src/main/java/store/itpick/backend/controller/DebateController.java
@@ -117,4 +117,12 @@ public class DebateController {
         debateService.deleteDebate(debateId,userId);
         return new BaseResponse<>(null);
     }
+
+
+    @GetMapping("/trend")
+    public BaseResponse<List<DebateByKeywordDTO>> getTrendDebate(){
+        List<DebateByKeywordDTO> debateResponse = debateService.updateHotDebate();
+
+        return new BaseResponse<>(debateResponse);
+    }
 }

--- a/src/main/java/store/itpick/backend/controller/DebateController.java
+++ b/src/main/java/store/itpick/backend/controller/DebateController.java
@@ -121,7 +121,7 @@ public class DebateController {
 
     @GetMapping("/trend")
     public BaseResponse<List<DebateByKeywordDTO>> getTrendDebate(){
-        List<DebateByKeywordDTO> debateResponse = debateService.updateHotDebate();
+        List<DebateByKeywordDTO> debateResponse = debateService.getHotDebate();
 
         return new BaseResponse<>(debateResponse);
     }

--- a/src/main/java/store/itpick/backend/dto/debate/DebateByKeywordDTO.java
+++ b/src/main/java/store/itpick/backend/dto/debate/DebateByKeywordDTO.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @Getter
 public class DebateByKeywordDTO {
     String title;
-    String content;
+    Long debateId;
     String mediaUrl;
     Long hit;
     Long comment;

--- a/src/main/java/store/itpick/backend/model/TrendDebate.java
+++ b/src/main/java/store/itpick/backend/model/TrendDebate.java
@@ -1,0 +1,28 @@
+package store.itpick.backend.model;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.sql.Timestamp;
+
+@Entity
+@Table(name = "trend_debate")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TrendDebate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trend_debate_id")
+    private Long trendDebateId;
+
+    @OneToOne
+    @JoinColumn(name = "debate_id", nullable = false)
+    private Debate debate;
+
+    @Column(name = "update_at", nullable = false)
+    private Timestamp updateAt;
+}

--- a/src/main/java/store/itpick/backend/repository/DebateRepository.java
+++ b/src/main/java/store/itpick/backend/repository/DebateRepository.java
@@ -1,5 +1,6 @@
 package store.itpick.backend.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -8,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import store.itpick.backend.model.Debate;
 import store.itpick.backend.model.User;
 
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,6 +39,11 @@ public interface DebateRepository extends JpaRepository<Debate, Long> {
     void softDeleteById(@Param("debate_id") Long debate_id);
 
     Optional<Debate> getDebateByDebateId(Long debateId);
+
+    @Query("SELECT d FROM Debate d " +
+            "WHERE d.createAt >= :startTime " +
+            "ORDER BY d.hits DESC")
+    List<Debate> findTop3DebatesCreatedInLast3Days(@Param("startTime") Timestamp startTime, Pageable pageable);
 
 
 }

--- a/src/main/java/store/itpick/backend/repository/TrendDebateRepository.java
+++ b/src/main/java/store/itpick/backend/repository/TrendDebateRepository.java
@@ -1,0 +1,10 @@
+package store.itpick.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import store.itpick.backend.model.TrendDebate;
+
+@Repository
+public interface TrendDebateRepository extends JpaRepository<TrendDebate, Long> {
+    void deleteAll();
+}

--- a/src/main/java/store/itpick/backend/service/DebateService.java
+++ b/src/main/java/store/itpick/backend/service/DebateService.java
@@ -297,7 +297,7 @@ public class DebateService {
     }
 
     @Transactional
-    public List<DebateByKeywordDTO> updateHotDebate() {
+    public void updateHotDebate() {
         // 현재 시간 및 48시간 전 시간 계산
         Timestamp endTime = new Timestamp(System.currentTimeMillis());
         Timestamp startTime = new Timestamp(endTime.getTime() - 3 * 24 * 60 * 60 * 1000); // 3일 전 시간
@@ -308,7 +308,6 @@ public class DebateService {
 
         // 48시간 동안 조회수가 가장 많이 오른 상위 3개의 Debate 조회
         List<Debate> debateList = debateRepository.findTop3DebatesCreatedInLast3Days(startTime, pageRequest);
-        List<DebateByKeywordDTO> debates = new ArrayList<>();
 
         // 새로운 TrendDebate 엔트리 삽입
         for (Debate debate : debateList) {
@@ -319,9 +318,33 @@ public class DebateService {
 
             trendDebateRepository.save(trendDebate);
 
-            debates.add(new DebateByKeywordDTO(debate.getTitle(), debate.getDebateId(), debate.getImageUrl(), debate.getHits(), (long) debate.getComment().size()));
         }
 
+    }
+
+    @Transactional
+    public List<DebateByKeywordDTO> getHotDebate() {
+
+        // TrendDebate 테이블에서 현재 저장된 Debate 3개를 가져옵니다.
+        List<TrendDebate> trendDebates = trendDebateRepository.findAll();
+
+        // DebateByKeywordDTO 리스트 초기화
+        List<DebateByKeywordDTO> debates = new ArrayList<>();
+
+        // TrendDebate에 있는 Debate를 DebateByKeywordDTO로 변환하여 리스트에 추가
+        for (TrendDebate trendDebate : trendDebates) {
+            Debate debate = trendDebate.getDebate();
+            DebateByKeywordDTO debateDTO = new DebateByKeywordDTO(
+                    debate.getTitle(),
+                    debate.getDebateId(),
+                    debate.getImageUrl(),
+                    debate.getHits(),
+                    (long) debate.getComment().size()
+            );
+            debates.add(debateDTO);
+        }
+
+        // 최종 리스트 반환
         return debates;
     }
 

--- a/src/main/java/store/itpick/backend/service/SchedulerService.java
+++ b/src/main/java/store/itpick/backend/service/SchedulerService.java
@@ -24,6 +24,7 @@ public class SchedulerService {
 
     private final SeleniumService seleniumService;
     private final KeywordService keywordService;
+    private final DebateService debateService;
     private final Redis redis;
 
 
@@ -145,6 +146,11 @@ public class SchedulerService {
 
 
         log.info("Weekly task completed.");
+    }
+
+    @Scheduled(cron = "0 30 * * * *")
+    public void updateTrendDebate(){
+        debateService.updateHotDebate();
     }
 
 }


### PR DESCRIPTION
<img width="536" alt="image" src="https://github.com/user-attachments/assets/dbfb16cf-269b-4a6c-afbd-10427ed311c7">

</br>

# 인기 토론 선정 기준

72시간안에 만들어진 토론 중에서, 가장 조회수가 높은 3개의 토론을 저장합니다

</br>
</br>

# TrendDebate 테이블 추가
<img width="888" alt="image" src="https://github.com/user-attachments/assets/aa6bfcdb-baa9-4918-ac00-60f8ec6138d2">
</br>

- debateId
- trendId
- createAt
을 튜플로 가지고있음
</br>

</br>

# TrendDebate 설명 추가



- 현재 인기 토론이 무언인지 빨리 조회하기 위한 테이블입니다
- 72시간안에 만들어진 토론 중에서, 가장 조회수가 높은 3개의 토론을 저장
- 토론을 저장하기 전에 TrendDebate 테이블을 비워줘서, 항상 TrendDebate의 테이블에는 3개의 토론Id만 존재하고 있음
</br>

# Scheduler 추가

매시 30분마다 인기 게시글 업데이트

<img width="507" alt="image" src="https://github.com/user-attachments/assets/19ab2500-5b81-4640-92f7-5ffdf56e899e">

